### PR TITLE
Configure CircleCI and messenger env variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
     working_directory: ~/tbot
     docker:
       - image: elixir:1.5.2
+        environment:
+          MESSENGER_PAGE_TOKEN: does_not_matter_in_test_env
+          MESSENGER_PAGE_ID: also_does_not_matter_in_test_env
       - image: postgres:9.4.1
         environment:
           POSTGRES_USER: ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/tbot
+    docker:
+      - image: elixir:1.5.2
+      - image: postgres:9.4.1
+        environment:
+          POSTGRES_USER: ubuntu
+    steps:
+      - checkout
+      - run: mix local.hex --force
+      - run: mix local.rebar
+      - run: mix deps.get
+      - run: mix ecto.create
+      - run: mix test

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+export MESSENGER_PAGE_TOKEN="your_page_access_token"
+export MESSENGER_APP_ID="your_app_id_token"

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ npm-debug.log
 # secrets files as long as you replace their contents by environment
 # variables.
 /config/*.secret.exs
-/config/env.*.exs
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ npm-debug.log
 # secrets files as long as you replace their contents by environment
 # variables.
 /config/*.secret.exs
+/config/env.*.exs

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # Tbot
+
+### Bot written in Elixir with Phantom as a framework for learning purposes
+
+- [Dependencies](#dependencies)
+- [Setup](#setup)
+- [Development](#development)
+- [Tests](#tests)
+
+
+## Dependencies
+
+- PostgreSQL 9.6.1
+- Elixir >= 1.5
+
+## Setup
+
+```sh
+$ cp .env.example .env
+```
+
+Install hex package manager and rebar, install missing dependencies and create the storage for the repo
+
+```
+$ mix local.hex --force
+$ mix local.rebar
+$ mix deps.get
+$ mix ecto.create
+```
+
+# Developemnt
+
+**Note:** before executing any command that uses the environment variables in development mode, the following command must be executed:
+
+```sh
+$ touch .env
+```
+
+To start the server:
+
+```sh
+$ mix phx.server
+```
+
+# Tests
+
+```sh
+$ mix test
+```

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,8 @@ use Mix.Config
 
 # General application configuration
 config :tbot,
+  messenger_page_token: System.get_env("MESSENGER_PAGE_TOKEN"),
+  messenger_app_id: System.get_env("MESSENGER_APP_ID"),
   ecto_repos: [Tbot.Repo]
 
 # Configures the endpoint

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+import_config "env.local.exs"
+
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #
@@ -47,6 +49,10 @@ config :logger, :console, format: "[$level] $message\n"
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.
 config :phoenix, :stacktrace_depth, 20
+
+config :tbot,
+  messenger_page_token: System.get_env("MESSENGER_PAGE_TOKEN"),
+  messenger_app_id: System.get_env("MESSENGER_APP_ID")
 
 # Configure your database
 config :tbot, Tbot.Repo,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,5 @@
 use Mix.Config
 
-import_config "env.local.exs"
-
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #
@@ -49,10 +47,6 @@ config :logger, :console, format: "[$level] $message\n"
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.
 config :phoenix, :stacktrace_depth, 20
-
-config :tbot,
-  messenger_page_token: System.get_env("MESSENGER_PAGE_TOKEN"),
-  messenger_app_id: System.get_env("MESSENGER_APP_ID")
 
 # Configure your database
 config :tbot, Tbot.Repo,


### PR DESCRIPTION
Hi,

Here the circleci configuration file is added and the env variables from messenger are set up. 

In order to use these env variables in development, a `.env` file with the messenger variables must be created. To achieve this, just execute the following commands:

```
$ cp .env.example .env
```
Before doing anything with the app in development:

```
$ touch .env
```

