### PR TITLE
Add endpoint to verify messenger auth and rearrange env variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
         environment:
           MESSENGER_PAGE_TOKEN: does_not_matter_in_test_env
           MESSENGER_PAGE_ID: also_does_not_matter_in_test_env
+          MESSENGER_VERIFY_TOKEN: yup_like_the_previous_ones
       - image: postgres:9.4.1
         environment:
           POSTGRES_USER: ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: elixir:1.5.2
         environment:
+          MIX_ENV: test
           MESSENGER_PAGE_TOKEN: does_not_matter_in_test_env
           MESSENGER_PAGE_ID: also_does_not_matter_in_test_env
           MESSENGER_VERIFY_TOKEN: yup_like_the_previous_ones

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-export MESSENGER_PAGE_TOKEN="your_page_access_token"
-export MESSENGER_APP_ID="your_app_id_token"

--- a/README.md
+++ b/README.md
@@ -13,8 +13,15 @@
 
 ## Setup
 
-```sh
-$ cp .env.example .env
+Create the following file to store tokens for development environments, `tbot/config/dev.secret.exs`, and add the contents below:
+
+```ex
+use Mix.Config
+
+config :tbot,
+  messenger_verify_token: "your_messenger_verify_token",
+  messenger_app_id: "your_messenger_app_id",
+  messenger_page_token: "your_messenger_page_token"
 ```
 
 Install hex package manager and rebar, install missing dependencies and create the storage for the repo

--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ $ mix ecto.create
 
 ## Developemnt
 
-**Note:** before executing any command that uses the environment variables in development mode, the following command must be executed:
-
-```sh
-$ touch .env
-```
-
 To start the server:
 
 ```sh

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,8 +7,6 @@ use Mix.Config
 
 # General application configuration
 config :tbot,
-  messenger_page_token: System.get_env("MESSENGER_PAGE_TOKEN"),
-  messenger_app_id: System.get_env("MESSENGER_APP_ID"),
   ecto_repos: [Tbot.Repo]
 
 # Configures the endpoint

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -56,3 +56,5 @@ config :tbot, Tbot.Repo,
   database: "tbot_dev",
   hostname: "localhost",
   pool_size: 10
+
+import_config "dev.secret.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,10 @@
 use Mix.Config
 
+config :tbot,
+  messenger_verify_token: "blabla",
+  messenger_app_id: "blabla",
+  messenger_page_token: "blabla"
+
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :tbot, TbotWeb.Endpoint,

--- a/lib/tbot_web/controllers/page_controller.ex
+++ b/lib/tbot_web/controllers/page_controller.ex
@@ -1,7 +1,0 @@
-defmodule TbotWeb.PageController do
-  use TbotWeb, :controller
-
-  def index(conn, _params) do
-    render conn, "index.html"
-  end
-end

--- a/lib/tbot_web/controllers/tbot_controller.ex
+++ b/lib/tbot_web/controllers/tbot_controller.ex
@@ -1,0 +1,15 @@
+defmodule TbotWeb.TbotController do
+  use TbotWeb, :controller
+
+  def challenge(conn,
+    %{"hub.mode" => "subscribe", "hub.verify_token" => token, "hub.challenge" => challenge}) do
+    if token == verify_token do
+      conn |> send_resp(200, challenge)
+    else
+      conn |> put_status(500)
+    end
+  end
+
+  def challenge(conn, _), do: conn |> put_status(500)
+  defp verify_token, do: Application.get_env(:tbot, :messenger_verify_token)
+end

--- a/lib/tbot_web/router.ex
+++ b/lib/tbot_web/router.ex
@@ -1,26 +1,13 @@
 defmodule TbotWeb.Router do
   use TbotWeb, :router
 
-  pipeline :browser do
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
-  end
-
-  pipeline :api do
+  pipeline :messenger do
     plug :accepts, ["json"]
   end
 
   scope "/", TbotWeb do
-    pipe_through :browser # Use the default browser stack
+    pipe_through :messenger
 
-    get "/", PageController, :index
+    get "/bot", TbotController, :challenge
   end
-
-  # Other scopes may use custom stacks.
-  # scope "/api", TbotWeb do
-  #   pipe_through :api
-  # end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Tbot.Mixfile do
       {:phoenix_html, "~> 2.10"},
       {:phoenix_live_reload, "~> 1.0", only: :dev},
       {:gettext, "~> 0.11"},
-      {:cowboy, "~> 1.0"}
+      {:cowboy, "~> 1.0"},
     ]
   end
 

--- a/test/tbot_web/controllers/page_controller_test.exs
+++ b/test/tbot_web/controllers/page_controller_test.exs
@@ -1,8 +1,0 @@
-defmodule TbotWeb.PageControllerTest do
-  use TbotWeb.ConnCase
-
-  test "GET /", %{conn: conn} do
-    conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
-  end
-end

--- a/test/tbot_web/controllers/tbot_controller_test.exs
+++ b/test/tbot_web/controllers/tbot_controller_test.exs
@@ -28,6 +28,6 @@ defmodule TbotWeb.PageControllerTest do
     assert test_conn.status == 500
   end
 
-  defp corrent_verify_token, do: Application.get_env(:tbot, :messenger_verify_token)
+  defp correct_verify_token, do: Application.get_env(:tbot, :messenger_verify_token)
   defp incorrent_verify_token, do: "não consegue, né, moisés"
 end

--- a/test/tbot_web/controllers/tbot_controller_test.exs
+++ b/test/tbot_web/controllers/tbot_controller_test.exs
@@ -4,9 +4,9 @@ defmodule TbotWeb.PageControllerTest do
   test "GET /bot with correct verify token returns challenge token and 200", %{conn: conn} do
     test_conn = conn
     |> put_req_header("accept", "application/json")
-    |> get("/bot", %{"hub.mode" => "subscribe", "hub.verify_token" => corrent_verify_token, "hub.challenge" => "blabla"})
+    |> get("/bot", %{"hub.mode" => "subscribe", "hub.verify_token" => correct_verify_token, "hub.challenge" => "blabla"})
 
-    assert test_conn.resp_body == corrent_verify_token
+    assert test_conn.resp_body == correct_verify_token
     assert test_conn.status == 200
   end
 

--- a/test/tbot_web/controllers/tbot_controller_test.exs
+++ b/test/tbot_web/controllers/tbot_controller_test.exs
@@ -1,0 +1,33 @@
+defmodule TbotWeb.PageControllerTest do
+  use TbotWeb.ConnCase
+
+  test "GET /bot with correct verify token returns challenge token and 200", %{conn: conn} do
+    test_conn = conn
+    |> put_req_header("accept", "application/json")
+    |> get("/bot", %{"hub.mode" => "subscribe", "hub.verify_token" => corrent_verify_token, "hub.challenge" => "blabla"})
+
+    assert test_conn.resp_body == corrent_verify_token
+    assert test_conn.status == 200
+  end
+
+  test "GET /bot with incorrect verify token returns 500", %{conn: conn} do
+    test_conn = conn
+    |> put_req_header("accept", "application/json")
+    |> get("/bot", %{"hub.mode" => "subscribe", "hub.verify_token" => incorrent_verify_token, "hub.challenge" => "blabla"})
+
+    assert test_conn.resp_body == nil
+    assert test_conn.status == 500
+  end
+
+  test "GET /bot with incorrect params returns 500", %{conn: conn} do
+    test_conn = conn
+    |> put_req_header("accept", "application/json")
+    |> get("/bot", %{})
+
+    assert test_conn.resp_body == nil
+    assert test_conn.status == 500
+  end
+
+  defp corrent_verify_token, do: Application.get_env(:tbot, :messenger_verify_token)
+  defp incorrent_verify_token, do: "não consegue, né, moisés"
+end


### PR DESCRIPTION
Hi,

Here we made some progress, boy! First and foremost, a GET endpoint was created in order to authenticate the challenge request that messenger does in order to connect to our server. Also, a better way to set the proper messenger tokens was done. Now, instead of having to `touch .env`, we put them in a `dev.secrets.exs` and they are only used in dev mode. 

For last, I have no idea why, but `Mix.env` in CircleCI returns `dev`, therefore, the env variable `MIX_ENV` is explicitly exported in `circleci/.config.yml`