### PR TITLE
Add post endpoint and POC messenger return value

### DIFF
--- a/lib/tbot_web/controllers/tbot_controller.ex
+++ b/lib/tbot_web/controllers/tbot_controller.ex
@@ -1,5 +1,6 @@
 defmodule TbotWeb.TbotController do
   use TbotWeb, :controller
+  import Tbot.MessengerHelper
 
   def challenge(conn,
     %{"hub.mode" => "subscribe", "hub.verify_token" => token, "hub.challenge" => challenge}) do
@@ -9,7 +10,13 @@ defmodule TbotWeb.TbotController do
       conn |> put_status(500)
     end
   end
-
   def challenge(conn, _), do: conn |> put_status(500)
+
+  def webhook(conn, %{"entry" => entry, "object" => "page"}) do
+    parsed_entry = parse_messenger_entry(entry)
+    conn |> send_resp(200, Poison.encode!(parsed_entry))
+  end
+  def webhook(conn, _),  do: conn |> put_status(500)
+
   defp verify_token, do: Application.get_env(:tbot, :messenger_verify_token)
 end

--- a/lib/tbot_web/helpers/messenger_helper.ex
+++ b/lib/tbot_web/helpers/messenger_helper.ex
@@ -1,0 +1,19 @@
+defmodule Tbot.MessengerHelper do
+  def parse_messenger_entry(entry) do
+    text  = parse_message_key(entry)
+    sender_id  = parse_sender_key(entry)
+    %{"text": text, "sender_id": sender_id}
+  end
+
+  defp parse_message_key(msg) do
+    parse_messaging_key(msg)
+    |> hd |> Map.get("message") |> Map.get("text")
+  end
+
+  defp parse_sender_key(msg) do
+    parse_messaging_key(msg)
+    |> hd |> Map.get("sender") |> Map.get("id")
+  end
+
+  defp parse_messaging_key(msgn), do: msgn |> hd |>  Map.get("messaging")
+end

--- a/lib/tbot_web/helpers/messenger_helper.ex
+++ b/lib/tbot_web/helpers/messenger_helper.ex
@@ -5,6 +5,7 @@ defmodule Tbot.MessengerHelper do
     %{"text": text, "sender_id": sender_id}
   end
 
+  # TODO: Take into consideration that a user may not send a text
   defp parse_message_key(msg) do
     parse_messaging_key(msg)
     |> hd |> Map.get("message") |> Map.get("text")

--- a/lib/tbot_web/router.ex
+++ b/lib/tbot_web/router.ex
@@ -9,5 +9,6 @@ defmodule TbotWeb.Router do
     pipe_through :messenger
 
     get "/bot", TbotController, :challenge
+    post "/bot", TbotController, :webhook
   end
 end

--- a/test/tbot_web/controllers/tbot_controller_test.exs
+++ b/test/tbot_web/controllers/tbot_controller_test.exs
@@ -60,18 +60,18 @@ defmodule TbotWeb.PageControllerTest do
     %{
       "object" => "page",
       "entry" => [%{
-          "id" => "1231930516917414",
-          "time" => "1500408432080",
-          "messaging" => [%{
-              "sender" => %{"id" => sender_id},
-              "recipient" => %{"id" => "1231930516917414"},
-              "timestamp" => "1500408431958",
-              "message" => %{
-                  "mid" => "mid.$cAAQ6nOh9tL9jiJUNVldV0_Eirk_R",
-                  "seq" => "30259",
-                  "text" => text,
-              }
-          }]
+        "id" => "1231930516917414",
+        "time" => "1500408432080",
+        "messaging" => [%{
+          "sender" => %{"id" => sender_id},
+          "recipient" => %{"id" => "1231930516917414"},
+          "timestamp" => "1500408431958",
+          "message" => %{
+            "mid" => "mid.$cAAQ6nOh9tL9jiJUNVldV0_Eirk_R",
+            "seq" => "30259",
+            "text" => text,
+          }
+        }]
       }]
     }
   end

--- a/test/tbot_web/controllers/tbot_controller_test.exs
+++ b/test/tbot_web/controllers/tbot_controller_test.exs
@@ -28,6 +28,51 @@ defmodule TbotWeb.PageControllerTest do
     assert test_conn.status == 500
   end
 
+  test "POST /bot with 'object': 'page' returns 200 and body", %{conn: conn} do
+    [sender_id | text] = ["123456", "blabla"]
+    test_conn = conn
+    |> put_req_header("accept", "application/json")
+    |> post("/bot", stub_post_messenger(sender_id, text))
+
+    assert test_conn.resp_body == Poison.encode!(%{"text" => text, "sender_id" => sender_id})
+    assert test_conn.status == 200
+  end
+
+  test "POST /bot without 'object': 'page' returns 500", %{conn: conn} do
+    test_conn = conn
+    |> put_req_header("accept", "application/json")
+    |> post("/bot", %{"object" => "not page", "entry": "not important"})
+
+    assert test_conn.status == 500
+  end
+
+  test "POST /bot with no body returns 500", %{conn: conn} do
+    test_conn = conn
+    |> put_req_header("accept", "application/json")
+    |> post("/bot", %{})
+
+    assert test_conn.status == 500
+  end
+
   defp correct_verify_token, do: Application.get_env(:tbot, :messenger_verify_token)
   defp incorrent_verify_token, do: "não consegue, né, moisés"
+  defp stub_post_messenger(sender_id, text) do
+    %{
+      "object" => "page",
+      "entry" => [%{
+          "id" => "1231930516917414",
+          "time" => "1500408432080",
+          "messaging" => [%{
+              "sender" => %{"id" => sender_id},
+              "recipient" => %{"id" => "1231930516917414"},
+              "timestamp" => "1500408431958",
+              "message" => %{
+                  "mid" => "mid.$cAAQ6nOh9tL9jiJUNVldV0_Eirk_R",
+                  "seq" => "30259",
+                  "text" => text,
+              }
+          }]
+      }]
+    }
+  end
 end


### PR DESCRIPTION
Hi,

In this PR a POST endpoint is implemented and it will serve as the messenger messages API. Right now, given a post from messenger (see `tbot_controller_test.ex`) we only respond with the `sender_id` and `text`, however, this is NOT the structure messenger requires in order "accept" our post request. I did this for the sake of implementation, in other words, it is just a POC, I will alter the return structure on the following PRs and also add `Agents` and `Tasks`.