### PR TITLE
Send messenger response in a task

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ For production tokens, insert in your `prod.secret.exs`:
 config :tbot,
   messenger_verify_token: System.get_env('MESSENGER_VERIFY_TOKEN'),
   messenger_page_token: System.get_env('MESSENGER_PAGE_TOKEN')
-
 ```
 
 Install hex package manager and rebar, install missing dependencies and create the storage for the repo

--- a/README.md
+++ b/README.md
@@ -25,8 +25,16 @@ use Mix.Config
 
 config :tbot,
   messenger_verify_token: "your_messenger_verify_token",
-  messenger_app_id: "your_messenger_app_id",
   messenger_page_token: "your_messenger_page_token"
+```
+
+For production tokens, insert in your `prod.secret.exs`:
+
+```ex
+config :tbot,
+  messenger_verify_token: System.get_env('MESSENGER_VERIFY_TOKEN'),
+  messenger_page_token: System.get_env('MESSENGER_PAGE_TOKEN')
+
 ```
 
 Install hex package manager and rebar, install missing dependencies and create the storage for the repo

--- a/lib/tbot/application.ex
+++ b/lib/tbot/application.ex
@@ -14,6 +14,7 @@ defmodule Tbot.Application do
       supervisor(Tbot.Repo, []),
       # Start the endpoint when the application starts
       supervisor(TbotWeb.Endpoint, []),
+      supervisor(Task.Supervisor, [[name: Tbot.TaskSupervisor, restart: :transient]])
       # Start your own worker by calling: Tbot.Worker.start_link(arg1, arg2, arg3)
       # worker(Tbot.Worker, [arg1, arg2, arg3]),
     ]

--- a/lib/tbot_web/endpoint.ex
+++ b/lib/tbot_web/endpoint.ex
@@ -1,7 +1,7 @@
 defmodule TbotWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :tbot
 
-  socket "/socket", TbotWeb.UserSocket
+  # socket "/socket", TbotWeb.UserSocket
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/lib/tbot_web/messenger/tbot_messenger_input.ex
+++ b/lib/tbot_web/messenger/tbot_messenger_input.ex
@@ -33,7 +33,10 @@ defmodule Tbot.MessengerInput do
   end
 
   defp parse_message_key(msg) do
-    message = msg |> parse_messaging_key |> hd |> Map.get("message")
+    message = msg
+    |> parse_messaging_key
+    |> hd
+    |> Map.get("message")
     define_message_type(message)
   end
 

--- a/lib/tbot_web/messenger/tbot_messenger_task.ex
+++ b/lib/tbot_web/messenger/tbot_messenger_task.ex
@@ -1,0 +1,16 @@
+defmodule Tbot.MessengerOutputTask do
+  @moduledoc """
+  Task responsible for building the Messenger resquest body and
+  sending it back to Messenger's user.
+  """
+
+  alias Tbot.MessengerOutput, as: MessengerOutput
+
+  def respond_messenger(parsed_entry) do
+    # NOTE: Not sure if "async_nolink" is the best supervisor option
+    Task.Supervisor.async_nolink Tbot.TaskSupervisor, fn ->
+      body = MessengerOutput.build_request_body(parsed_entry)
+      MessengerOutput.send(body)
+    end
+  end
+end

--- a/lib/tbot_web/messenger/tbot_messenger_task.ex
+++ b/lib/tbot_web/messenger/tbot_messenger_task.ex
@@ -7,7 +7,6 @@ defmodule Tbot.MessengerOutputTask do
   alias Tbot.MessengerOutput, as: MessengerOutput
 
   def respond_messenger(parsed_entry) do
-    # NOTE: Not sure if "async_nolink" is the best supervisor option
     Task.Supervisor.async_nolink Tbot.TaskSupervisor, fn ->
       body = MessengerOutput.build_request_body(parsed_entry)
       MessengerOutput.send(body)

--- a/lib/tbot_web/tbot_controller.ex
+++ b/lib/tbot_web/tbot_controller.ex
@@ -2,7 +2,7 @@ defmodule TbotWeb.TbotController do
   use TbotWeb, :controller
 
   alias Tbot.MessengerInput, as: MessengerInput
-  alias Tbot.MessengerOutput, as: MessengerOutput
+  alias Tbot.MessengerOutputTask, as: MessengerOutputTask
 
   def challenge(conn,
     %{"hub.mode" => "subscribe", "hub.verify_token" => token, "hub.challenge" => challenge}) do
@@ -16,10 +16,7 @@ defmodule TbotWeb.TbotController do
 
   def webhook(conn, %{"entry" => entry, "object" => "page"}) do
     parsed_entry = MessengerInput.parse_messenger_entry(entry)
-
-    # TODO: Send response in a "Task"
-    body = MessengerOutput.build_request_body(parsed_entry)
-    MessengerOutput.send(body)
+    MessengerOutputTask.respond_messenger(parsed_entry)
 
     conn |> send_resp(200, "ok")
   end

--- a/test/tbot_web/tbot_controller_test.exs
+++ b/test/tbot_web/tbot_controller_test.exs
@@ -28,7 +28,7 @@ defmodule TbotWeb.TbotControllerTest do
     assert test_conn.status == 500
   end
 
-  test "POST /bot with 'object': 'page' returns 200 and body", %{conn: conn} do
+  test "POST /bot with 'object': 'page' returns 200", %{conn: conn} do
     with_mock HTTPotion, [post: fn(_url, _headers_and_body) -> "ok" end] do
       [sender_id | text] = ["123456", "blabla"]
       test_conn = conn

--- a/test/tbot_web/tbot_messenger_input_test.exs
+++ b/test/tbot_web/tbot_messenger_input_test.exs
@@ -1,7 +1,6 @@
 defmodule TbotWeb.TbotMessengerInputTest do
   use TbotWeb.ConnCase
 
-  alias Tbot.MessengerRequestData, as: MessengerRequestData
   alias Tbot.MessengerInput, as: MessengerInput
 
   test "messenger entry value returns sender_id and text" do

--- a/test/tbot_web/tbot_messenger_output_test.exs
+++ b/test/tbot_web/tbot_messenger_output_test.exs
@@ -3,7 +3,6 @@ defmodule TbotWeb.TbotMessengerOutputTest do
 
   alias Tbot.MessengerOutput, as: MessengerOutput
   alias Tbot.MessengerRequestData, as: MessengerRequestData
-  alias Tbot.MessengerResponsetData, as: MessengerResponsetData
 
   import Mock
 

--- a/test/tbot_web/tbot_messenger_task_test.exs
+++ b/test/tbot_web/tbot_messenger_task_test.exs
@@ -1,0 +1,21 @@
+defmodule TbotWeb.MessengerOutputTaskTest do
+  use TbotWeb.ConnCase
+
+  alias Tbot.MessengerOutputTask, as: MessengerOutputTask
+  alias Tbot.MessengerOutput, as: MessengerOutput
+  alias Tbot.MessengerRequestData, as: RequestData
+
+  import Mock
+
+  test "'respond_messenge' starts task to answer user" do
+    with_mock HTTPotion, [post: fn(_url, _headers_and_body) -> "ok" end] do
+      message_map = %RequestData{message: "hi", sender_id: "1.61803398875", type: "text"}
+
+      task = MessengerOutputTask.respond_messenger(message_map)
+      ref  = Process.monitor(task.pid)
+      assert_receive {:DOWN, ^ref, :process, _, :normal}, 500
+    end
+  end
+
+  defp messenger_page_token, do: Application.get_env(:tbot, :messenger_page_token)
+end


### PR DESCRIPTION
Hi,

Here we refactor and optimize the code. Instead of sending Messenger's user POST requests in synchronous mode, they are now being sent in async mode. Elixir `Tasks` were used to achieve this. They are started with `async_nolink` (not sure if it is the best option) and monitored under `Tbot.TaskSupevisor`.

Another change was `README.md`'s update and removal of `messenger_app_id` because it is was not used.