### PR TITLE
Add guess checking and syncing

### DIFF
--- a/lib/tbot_web/hangman/tbot_hangman_sync_guesses.ex
+++ b/lib/tbot_web/hangman/tbot_hangman_sync_guesses.ex
@@ -1,0 +1,31 @@
+defmodule Tbot.HangmanSyncGuesses do
+  @moduledoc """
+  Module responsible for updating the correct and incorrect guesses key from the user
+  in their Redis hash. It appends to the preexisting guesses the correct or incorrect
+  guess and if there is no guess, it simply adds
+  """
+
+  alias Tbot.Redis, as: Redis
+
+  def update_correct_guess(guess_word, sender_id) do
+    conn = Redis.start_link
+
+    existent_correct_guesses = Redis.get_key_value(conn, sender_id, :correct_guesses)
+    if existent_correct_guesses == nil do
+      Redis.set(conn, sender_id, :correct_guesses, guess_word)
+    else
+      Redis.set(conn, sender_id, :correct_guesses, guess_word <> existent_correct_guesses)
+    end
+  end
+
+  def update_incorrect_guess(guess_word, sender_id) do
+    conn = Redis.start_link
+
+    existent_incorrect_guesses = Redis.get_key_value(conn, sender_id, :incorrect_guesses)
+    if existent_incorrect_guesses == nil do
+      Redis.set(conn, sender_id, :incorrect_guesses, guess_word)
+    else
+      Redis.set(conn, sender_id, :incorrect_guesses, guess_word <> existent_incorrect_guesses)
+    end
+  end
+end

--- a/lib/tbot_web/messenger/tbot_messenger_response_builder.ex
+++ b/lib/tbot_web/messenger/tbot_messenger_response_builder.ex
@@ -5,33 +5,61 @@ defmodule Tbot.MessengerResponseBuilder do
   """
 
   alias Tbot.Redis, as: Redis
-  alias Tbot.HangmanDrawings, as: HangmanDrawings
+  alias Tbot.Agent, as: Agent
+  alias Tbot.HangmanSyncGuesses, as: SyncGuesses
+  alias Tbot.HangmanDrawings, as: Drawings
 
   def response_data(
     %Tbot.MessengerRequestData{sender_id: sender_id, message: text, type: type}) do
 
-    # TODO: Implement checking for guesses' tries
-    %Tbot.MessengerRequestData{
-      sender_id: sender_id, message: first_interaction_message(sender_id), type: type
-    }
+    %Tbot.MessengerRequestData{sender_id: sender_id, message: define_interaction(text, sender_id), type: type}
   end
 
-  defp first_interaction_message(sender_id) do
-    sender_id
+  defp define_interaction(text, sender_id) do
+    text = if Agent.alive? do
+      chosen_word = Agent.get(sender_id)
+      Agent.stop
+      first_interaction_message(chosen_word)
+    else
+      check_for_guess(text, sender_id)
+    end
+  end
+
+  ############# FIRST INTERACTION METHODS #########################
+
+  defp first_interaction_message(chosen_word) do
+    chosen_word
     |> build_word_underscores
     |> merge_underscores_and_drawing
   end
 
-  defp build_word_underscores(sender_id) do
-    word = Redis.start_link |> Redis.get_key_value(sender_id, :chosen_word)
-    # In order to avoid nil results. See https://xkcd.com/221/
-    word = word || "Abracadabra"
-    String.duplicate("_ ", String.length(word) - 1) <> "_"
+  defp build_word_underscores(chosen_word) do
+    String.duplicate("_ ", String.length(chosen_word) - 1) <> "_"
   end
 
   defp merge_underscores_and_drawing(underscores) do
-    # TODO: Implement checking for guesses' tries
-    [drawing | sentence] = HangmanDrawings.draw(0)
+    [drawing | sentence] = Drawings.draw(0)
     drawing <> " #{underscores}" <> "\n\n" <> hd sentence
+  end
+
+  ###############################################################
+
+  defp check_for_guess(text, sender_id) do
+    if String.length(text) == 1 do
+      if is_guess_in_chosen_word?(text, sender_id) do
+        SyncGuesses.update_correct_guess(text, sender_id)
+        "correct"
+      else
+        SyncGuesses.update_incorrect_guess(text, sender_id)
+        "incorrect"
+      end
+    else
+      "Desculpe, não entendi"
+    end
+  end
+
+  defp is_guess_in_chosen_word?(text, sender_id) do
+    chosen_word = Redis.start_link |> Redis.get_key_value(sender_id, :chosen_word)
+    chosen_word =~ text
   end
 end

--- a/lib/tbot_web/tbot_agent.ex
+++ b/lib/tbot_web/tbot_agent.ex
@@ -6,6 +6,14 @@ defmodule Tbot.Agent do
     Agent.start_link(&Map.new/0, name: __MODULE__)
   end
 
+  def alive? do
+    Process.whereis(__MODULE__)
+  end
+
+  def stop do
+    Agent.stop(__MODULE__)
+  end
+
   def update(key, value) do
     Agent.update(__MODULE__, &Map.put(&1, key, value))
   end

--- a/lib/tbot_web/tbot_sync_user_chosen_word.ex
+++ b/lib/tbot_web/tbot_sync_user_chosen_word.ex
@@ -1,0 +1,20 @@
+defmodule Tbot.SyncUserChosenWord do
+  @moduledoc """
+  Module responsbile for fetching a random word, translating it to portuguese
+  and saving in Redis with the set name as the sender_id and the word as one
+  of the values
+  """
+  alias Tbot.HangmanWord, as: HangmanWord
+  alias Tbot.Redis, as: Redis
+  alias Tbot.Agent, as: Agent
+
+  def sync(magic_map) do
+    conn = Redis.start_link
+    word = HangmanWord.fetch_random_english_word |> HangmanWord.translate_to_portuguese
+
+    Agent.start_link
+    Agent.update(magic_map.sender_id, word)
+
+    Redis.set(conn, magic_map.sender_id, :chosen_word, word)
+  end
+end

--- a/test/tbot_web/hangman/tbot_hangman_sync_guesses_test.exs
+++ b/test/tbot_web/hangman/tbot_hangman_sync_guesses_test.exs
@@ -1,0 +1,62 @@
+defmodule Tbot.HangmanSyncGuessesTest do
+  use TbotWeb.ConnCase
+
+  alias Tbot.HangmanSyncGuesses, as: SyncGuesses
+  alias Tbot.Redis, as: Redis
+
+  setup_all do
+    {:ok, conn} = Redix.start_link(redis_host())
+    Redix.command!(conn, ["FLUSHDB"])
+    Redix.stop(conn)
+    :ok
+  end
+
+  setup context do
+    if context[:no_setup] do
+      {:ok, %{}}
+    else
+      {:ok, conn} = Redix.start_link(redis_host())
+      {:ok, %{conn: conn}}
+    end
+  end
+
+  test "'update_correct_guess' updates single and first guess", %{conn: conn} do
+    sender_id = "12345"
+    Redis.set(conn, sender_id, :chosen_word, "Bunda")
+
+    SyncGuesses.update_correct_guess("u", sender_id)
+
+    assert Redis.get_key_value(conn, sender_id, :correct_guesses) == "u"
+  end
+
+  test "'update_correct_guess' updates more guesses", %{conn: conn} do
+    sender_id = "123456"
+    Redis.set(conn, sender_id, :chosen_word, "Bunda")
+    Redis.set(conn, sender_id, :correct_guesses, "nd")
+
+    SyncGuesses.update_correct_guess("u", sender_id)
+
+    assert Redis.get_key_value(conn, sender_id, :correct_guesses) == "und"
+  end
+
+  test "'update_incorrect_guess' single and first guess", %{conn: conn} do
+    sender_id = "1234567"
+    Redis.set(conn, sender_id, :chosen_word, "Bunda")
+
+    SyncGuesses.update_incorrect_guess("q", sender_id)
+
+    assert Redis.get_key_value(conn, sender_id, :incorrect_guesses) == "q"
+  end
+
+  test "'update_incorrect_guess' updates more guesses", %{conn: conn} do
+    sender_id = "12345678"
+    Redis.set(conn, sender_id, :chosen_word, "Bunda")
+    Redis.set(conn, sender_id, :incorrect_guesses, "ls")
+
+    SyncGuesses.update_incorrect_guess("w", sender_id)
+
+    assert Redis.get_key_value(conn, sender_id, :incorrect_guesses) == "wls"
+  end
+
+  defp redis_host(), do: Application.get_env(:tbot, :redis_host)
+end

--- a/test/tbot_web/tbot_sync_user_chosen_word_test.exs
+++ b/test/tbot_web/tbot_sync_user_chosen_word_test.exs
@@ -1,0 +1,66 @@
+defmodule Tbot.SyncUserChosenWordTest do
+  use TbotWeb.ConnCase
+
+  alias Tbot.SyncUserChosenWord, as: SyncUserHangman
+
+  import Mock
+
+  setup_all do
+    {:ok, conn} = Redix.start_link(redis_host())
+    Redix.command!(conn, ["FLUSHDB"])
+    Redix.stop(conn)
+    :ok
+  end
+
+  test "'sync' fetches word and saves in redis" do
+    with_mock HTTPotion, [
+      get: fn(_url) -> stub_random_word_response() end,
+      post: fn(_url, _body_and_headers) -> stub_translation() end
+    ] do
+
+      sync = SyncUserHangman.sync(%{sender_id: "12345"})
+
+      assert sync == {:ok, 1}
+
+      {:ok, conn} = Redix.start_link(redis_host())
+      assert Redix.command(conn, ["HGETALL", "12345"]) == {:ok, ["chosen_word", "Mar Adriático"]}
+    end
+  end
+
+  defp stub_random_word_response() do
+    %HTTPotion.Response{
+      body: "{\"id\":349663,\"word\":\"unstepped\"}",
+      headers: %HTTPotion.Headers{
+        hdrs: %{
+          "access-control-allow-headers" => "Origin, X-Atmosphere-tracking-id, X-Atmosphere-Framework, X-Cache-Date, Content-Type, X-Atmosphere-Transport, X-Remote, api_key, auth_token, *",
+          "access-control-allow-methods" => "POST, GET, OPTIONS, PUT, DELETE",
+          "access-control-allow-origin" => "*",
+          "access-control-request-headers" => "Origin, X-Atmosphere-tracking-id, X-Atmosphere-Framework, X-Cache-Date, Content-Type, X-Atmosphere-Transport,  X-Remote, api_key, *",
+          "connection" => "close",
+          "content-type" => "application/json; charset=utf-8",
+          "date" => "Wed, 03 Jan 2018 19:29:45 GMT",
+          "wordnik-api-version" => "4.12.20"
+        }
+      },
+     status_code: 200
+    }
+  end
+
+  defp stub_translation() do
+    %HTTPotion.Response{
+      body: "{\"code\":200,\"lang\":\"en-pt\",\"text\":[\"Mar Adriático\"]}",
+      headers: %HTTPotion.Headers{
+        hdrs: %{
+          "cache-control" => "no-store",
+          "connection" => "keep-alive", "content-length" => "53",
+          "content-type" => "application/json; charset=utf-8",
+          "date" => "Wed, 03 Jan 2018 19:40:48 GMT", "keep-alive" => "timeout=120",
+          "server" => "nginx/1.6.2", "x-content-type-options" => "nosniff"
+        }
+      },
+     status_code: 200
+    }
+  end
+
+  defp redis_host(), do: Application.get_env(:tbot, :redis_host)
+end


### PR DESCRIPTION
Hi,

Here, one important module is created and another one implemented. `Tbot.HangmanSyncGuesses` is new, it, as the name says, synchronizes the guesses accordingly to the user messages. This means that if the user sends "g" and the chosen_word is "gorilla", the field `correct_guesses` will receive "g". This serves the same for when the use misses a guess.

Another change was that `Tbot.MessengerResponseBuilder` can now answer with "correct", "incorrect", "Desculpe, não entendi" and the first hangman drawing. If "correct" is sent, this means that the correct guesses fields were synced, the same for "incorrect", however, if "Desculpe, não entendi" is the response, the did user not type "oi" or a letter, this could be like "bla", "hnn" or anything outside these params. 

**Note:** The responses "correct" and "incorrect" will be altered to their corresponding hangman guesses drawing.
  