### PR TITLE
Reset all guesses if first interaction

### DIFF
--- a/lib/tbot_web/hangman/tbot_hangman_sync_guesses.ex
+++ b/lib/tbot_web/hangman/tbot_hangman_sync_guesses.ex
@@ -28,4 +28,10 @@ defmodule Tbot.HangmanSyncGuesses do
       Redis.set(conn, sender_id, :incorrect_guesses, guess_word <> existent_incorrect_guesses)
     end
   end
+
+  def reset_all_guesses(sender_id) do
+    conn = Redis.start_link
+    Redis.set(conn, sender_id, :correct_guesses, "")
+    Redis.set(conn, sender_id, :incorrect_guesses, "")
+  end
 end

--- a/lib/tbot_web/messenger/tbot_messenger_response_builder.ex
+++ b/lib/tbot_web/messenger/tbot_messenger_response_builder.ex
@@ -19,7 +19,7 @@ defmodule Tbot.MessengerResponseBuilder do
     text = if Agent.alive? do
       chosen_word = Agent.get(sender_id)
       Agent.stop
-      first_interaction_message(chosen_word)
+      first_interaction_message(chosen_word, sender_id)
     else
       check_for_guess(text, sender_id)
     end
@@ -27,7 +27,8 @@ defmodule Tbot.MessengerResponseBuilder do
 
   ############# FIRST INTERACTION METHODS #########################
 
-  defp first_interaction_message(chosen_word) do
+  defp first_interaction_message(chosen_word, sender_id) do
+    SyncGuesses.reset_all_guesses(sender_id)
     chosen_word
     |> build_word_underscores
     |> merge_underscores_and_drawing

--- a/test/tbot_web/hangman/tbot_hangman_sync_guesses_test.exs
+++ b/test/tbot_web/hangman/tbot_hangman_sync_guesses_test.exs
@@ -58,5 +58,16 @@ defmodule Tbot.HangmanSyncGuessesTest do
     assert Redis.get_key_value(conn, sender_id, :incorrect_guesses) == "wls"
   end
 
+  test "'reset_all_guesses' reset all guesses", %{conn: conn} do
+    sender_id = "12345678"
+    Redis.set(conn, sender_id, :chosen_word, "Bunda")
+    Redis.set(conn, sender_id, :incorrect_guesses, "ls")
+
+    SyncGuesses.reset_all_guesses(sender_id)
+
+    assert Redis.get_key_value(conn, sender_id, :incorrect_guesses) == ""
+    assert Redis.get_key_value(conn, sender_id, :correct_guesses) == ""
+  end
+
   defp redis_host(), do: Application.get_env(:tbot, :redis_host)
 end


### PR DESCRIPTION
Hi,

Here a bug is fixed regarding the guesses. Before, if a new chosen word was acquired (another first interaction), the incorrect and correct guesses were not reset. This means that the user would be kept with the same guesses for all the previous chosen words