### PR TITLE
Implement a Redis connection pool

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,6 +13,9 @@ config :tbot, TbotWeb.Endpoint,
   pubsub: [name: Tbot.PubSub,
            adapter: Phoenix.PubSub.PG2]
 
+config :tbot,
+  redis_pool_size: System.get_env("REDIS_POOL_SIZE") || 50
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/lib/tbot_web/hangman/tbot_hangman_build_drawing.ex
+++ b/lib/tbot_web/hangman/tbot_hangman_build_drawing.ex
@@ -67,18 +67,16 @@ defmodule Tbot.HangmanBuildDrawing do
     drawing <> " #{underscores}\n"
   end
 
- defp chosen_word_and_guesses_subtraction(sender_id, chosen_word) do
-  # Exaplanation: for a string of random or not-random substrings of a string, remove them form the string
-  # Example: remove "tin" from "Anitta"
-  # Result: "Aa"
-  correct_guesses = correct_guesses(sender_id)
-  map_reduce_string(String.split(correct_guesses, "", trim: true), chosen_word, "")
- end
+  defp chosen_word_and_guesses_subtraction(sender_id, chosen_word) do
+    # Exaplanation: for a string of random or not-random substrings of a string, remove them form the string
+    # Example: remove "tin" from "Anitta"
+    # Result: "Aa"
+    correct_guesses = correct_guesses(sender_id)
+    map_reduce_string(String.split(correct_guesses, "", trim: true), chosen_word, "")
+  end
 
- defp incorrect_guess_count(sender_id) do
-  incorrect_guesses =
-    Redis.start_link
-    |> Redis.get_key_value(sender_id, :incorrect_guesses)
+  defp incorrect_guess_count(sender_id) do
+    incorrect_guesses = Redis.get_key_value(sender_id, :incorrect_guesses)
 
     case incorrect_guesses do
       nil -> 0
@@ -87,9 +85,7 @@ defmodule Tbot.HangmanBuildDrawing do
   end
 
   defp correct_guesses(sender_id) do
-    correct_guesses =
-      Redis.start_link
-      |> Redis.get_key_value(sender_id, :correct_guesses)
+    correct_guesses = Redis.get_key_value(sender_id, :correct_guesses)
 
     case correct_guesses do
       nil -> ""
@@ -98,7 +94,6 @@ defmodule Tbot.HangmanBuildDrawing do
   end
 
   defp chosen_word(sender_id) do
-    Redis.start_link
-    |> Redis.get_key_value(sender_id, :chosen_word)
+    Redis.get_key_value(sender_id, :chosen_word)
   end
 end

--- a/lib/tbot_web/hangman/tbot_hangman_response_builder.ex
+++ b/lib/tbot_web/hangman/tbot_hangman_response_builder.ex
@@ -45,9 +45,7 @@ defmodule Tbot.HangmanResponseBuilder do
   end
 
   defp incorrect_guess_count(sender_id) do
-    incorrect_guesses =
-      Redis.start_link
-      |> Redis.get_key_value(sender_id, :incorrect_guesses)
+    incorrect_guesses = Redis.get_key_value(sender_id, :incorrect_guesses)
 
     case incorrect_guesses do
       nil -> 0
@@ -63,7 +61,6 @@ defmodule Tbot.HangmanResponseBuilder do
   end
 
   defp is_guess_in_chosen_word?(text, sender_id) do
-    chosen_word = Redis.start_link |> Redis.get_key_value(sender_id, :chosen_word)
-    chosen_word =~ text
+    Redis.get_key_value(sender_id, :chosen_word) =~ text
   end
 end

--- a/lib/tbot_web/hangman/tbot_hangman_sync_guesses.ex
+++ b/lib/tbot_web/hangman/tbot_hangman_sync_guesses.ex
@@ -9,23 +9,20 @@ defmodule Tbot.HangmanSyncGuesses do
   alias Tbot.HangmanWord, as: NewChosenWord
 
   def update_guesses(guess, guess_flag, sender_id) do
-    conn = Redis.start_link
-
-    existent_guesses = Redis.get_key_value(conn, sender_id, guess_flag)
+    existent_guesses = Redis.get_key_value(sender_id, guess_flag)
     if existent_guesses == nil do
-      Redis.set(conn, sender_id, guess_flag, guess)
+      Redis.set(sender_id, guess_flag, guess)
     else
-      Redis.set(conn, sender_id, guess_flag, guess <> existent_guesses)
+      Redis.set(sender_id, guess_flag, guess <> existent_guesses)
     end
   end
 
   def reset_chosen_word(sender_id) do
-    Redis.start_link |> Redis.set(sender_id, :chosen_word, "")
+    Redis.set(sender_id, :chosen_word, "")
   end
 
   def reset_all_guesses(sender_id) do
-    conn = Redis.start_link
-    Redis.set(conn, sender_id, :correct_guesses, "")
-    Redis.set(conn, sender_id, :incorrect_guesses, "")
+    Redis.set(sender_id, :correct_guesses, "")
+    Redis.set(sender_id, :incorrect_guesses, "")
   end
 end

--- a/lib/tbot_web/tbot_redis.ex
+++ b/lib/tbot_web/tbot_redis.ex
@@ -1,23 +1,23 @@
 defmodule Tbot.Redis do
   @moduledoc false
-  def start_link do
-   {:ok, conn} = Redix.start_link(redis_host())
-   conn
+  def set(name, key, value) do
+    Redix.command(:"redix_#{random_index()}", ["HSET", name, key, value])
   end
 
-  def set(conn, name, key, value) do
-    Redix.command(conn, ["HSET", name, key, value])
-  end
-
-  def get_members(conn, name) do
-    {:ok, value} = Redix.command(conn, ["HGETALL", name])
+  def get_members(name) do
+    {:ok, value} = Redix.command(:"redix_#{random_index()}", ["HGETALL", name])
     value
   end
 
-  def get_key_value(conn, name, key) do
-    {:ok, value} = Redix.command(conn, ["HGET", name, key])
+  def get_key_value(name, key) do
+    {:ok, value} = Redix.command(:"redix_#{random_index()}", ["HGET", name, key])
     value
   end
 
+  defp random_index() do
+    rem(System.unique_integer([:positive]), redis_pool_size())
+  end
+
+  defp redis_pool_size(), do: Application.get_env(:tbot, :redis_pool_size)
   defp redis_host(), do: Application.get_env(:tbot, :redis_host)
 end

--- a/lib/tbot_web/tbot_redis.ex
+++ b/lib/tbot_web/tbot_redis.ex
@@ -14,6 +14,10 @@ defmodule Tbot.Redis do
     value
   end
 
+  def command(command) do
+    {:ok, value} = Redix.command(:"redix_#{random_index()}", command)
+  end
+
   defp random_index() do
     rem(System.unique_integer([:positive]), redis_pool_size())
   end

--- a/lib/tbot_web/tbot_sync_user_chosen_word.ex
+++ b/lib/tbot_web/tbot_sync_user_chosen_word.ex
@@ -9,12 +9,11 @@ defmodule Tbot.SyncUserChosenWord do
   alias Tbot.Agent
 
   def sync(magic_map) do
-    conn = Redis.start_link
     word = HangmanWord.fetch_random_english_word |> HangmanWord.translate_to_portuguese
 
     Agent.start_link
     Agent.update(magic_map.sender_id, :first_interaction)
 
-    Redis.set(conn, magic_map.sender_id, :chosen_word, word)
+    Redis.set(magic_map.sender_id, :chosen_word, word)
   end
 end

--- a/test/tbot_web/hangman/tbot_hangman_build_drawing_test.exs
+++ b/test/tbot_web/hangman/tbot_hangman_build_drawing_test.exs
@@ -5,26 +5,15 @@ defmodule Tbot.HangmanBuildDrawingTest do
   alias Tbot.HangmanBuildDrawing, as: BuildDrawing
 
   setup do
-    {:ok, conn} = Redix.start_link(redis_host())
-    Redix.command!(conn, ["FLUSHDB"])
-    Redix.stop(conn)
+    Redis.command(["FLUSHDB"])
     :ok
   end
 
-  setup context do
-    if context[:no_setup] do
-      {:ok, %{}}
-    else
-      {:ok, conn} = Redix.start_link(redis_host())
-      {:ok, %{conn: conn}}
-    end
-  end
-
-  test "first guess with correct letter", %{conn: conn} do
+  test "first guess with correct letter" do
     sender_id = "12345"
     guess = "A"
-    save_word_in_redis(conn, sender_id, "Anitta")
-    update_redis(conn, sender_id, :correct_guesses, guess)
+    save_word_in_redis(sender_id, "Anitta")
+    update_redis(sender_id, :correct_guesses, guess)
 
     drawing = BuildDrawing.get_drawing(sender_id)
 
@@ -41,12 +30,12 @@ defmodule Tbot.HangmanBuildDrawingTest do
     assert drawing == correct_drawing
   end
 
-  test "third correct guess with two incorrect guesses", %{conn: conn} do
+  test "third correct guess with two incorrect guesses" do
     sender_id = "12345"
     guess = "A"
-    save_word_in_redis(conn, sender_id, "Anitta")
-    update_redis(conn, sender_id, :correct_guesses, guess <> "an")
-    update_redis(conn, sender_id, :incorrect_guesses, "wo")
+    save_word_in_redis(sender_id, "Anitta")
+    update_redis(sender_id, :correct_guesses, guess <> "an")
+    update_redis(sender_id, :incorrect_guesses, "wo")
 
     drawing = BuildDrawing.get_drawing(sender_id)
 
@@ -63,12 +52,12 @@ defmodule Tbot.HangmanBuildDrawingTest do
     assert drawing == correct_drawing
   end
 
-  test "fifth incorrect guess with three correct guesses", %{conn: conn} do
+  test "fifth incorrect guess with three correct guesses" do
     sender_id = "12345"
     guess = "w"
-    save_word_in_redis(conn, sender_id, "Anitta")
-    update_redis(conn, sender_id, :correct_guesses, "anA")
-    update_redis(conn, sender_id, :incorrect_guesses, guess <> "pozr")
+    save_word_in_redis(sender_id, "Anitta")
+    update_redis(sender_id, :correct_guesses, "anA")
+    update_redis(sender_id, :incorrect_guesses, guess <> "pozr")
 
     drawing = BuildDrawing.get_drawing(sender_id)
 
@@ -85,11 +74,11 @@ defmodule Tbot.HangmanBuildDrawingTest do
     assert drawing == correct_drawing
   end
 
-  test "first guess with incorrect letter", %{conn: conn} do
+  test "first guess with incorrect letter" do
     sender_id = "12345"
     guess = "w"
-    save_word_in_redis(conn, sender_id, "Anitta")
-    update_redis(conn, sender_id, :incorrect_guesses, guess)
+    save_word_in_redis(sender_id, "Anitta")
+    update_redis(sender_id, :incorrect_guesses, guess)
 
     drawing = BuildDrawing.get_drawing(sender_id)
 
@@ -106,11 +95,11 @@ defmodule Tbot.HangmanBuildDrawingTest do
     assert drawing == correct_drawing
   end
 
-  test "fourth guess with incorrect letter", %{conn: conn} do
+  test "fourth guess with incorrect letter" do
     sender_id = "12345"
     guess = "p"
-    save_word_in_redis(conn, sender_id, "Anitta")
-    update_redis(conn, sender_id, :incorrect_guesses, guess <> "wdb")
+    save_word_in_redis(sender_id, "Anitta")
+    update_redis(sender_id, :incorrect_guesses, guess <> "wdb")
 
     drawing = BuildDrawing.get_drawing(sender_id)
 
@@ -127,13 +116,11 @@ defmodule Tbot.HangmanBuildDrawingTest do
     assert drawing == correct_drawing
   end
 
-  defp save_word_in_redis(conn, sender_id, chosen_word) do
-    Redis.set(conn, sender_id, :chosen_word, chosen_word)
+  defp save_word_in_redis(sender_id, chosen_word) do
+    Redis.set(sender_id, :chosen_word, chosen_word)
   end
 
-  defp update_redis(conn, sender_id, key, value) do
-    Redis.set(conn, sender_id, key, value)
+  defp update_redis(sender_id, key, value) do
+    Redis.set(sender_id, key, value)
   end
-
-  defp redis_host(), do: Application.get_env(:tbot, :redis_host)
 end

--- a/test/tbot_web/hangman/tbot_hangman_sync_guesses_test.exs
+++ b/test/tbot_web/hangman/tbot_hangman_sync_guesses_test.exs
@@ -4,105 +4,58 @@ defmodule Tbot.HangmanSyncGuessesTest do
   alias Tbot.HangmanSyncGuesses, as: SyncGuesses
   alias Tbot.Redis, as: Redis
 
-  setup_all do
-    {:ok, conn} = Redix.start_link(redis_host())
-    Redix.command!(conn, ["FLUSHDB"])
-    Redix.stop(conn)
+  setup do
+    Redis.command(["FLUSHDB"])
     :ok
   end
 
-  setup context do
-    if context[:no_setup] do
-      {:ok, %{}}
-    else
-      {:ok, conn} = Redix.start_link(redis_host())
-      {:ok, %{conn: conn}}
-    end
-  end
-
-  test "'update_guesses' updates correct single and first guess", %{conn: conn} do
+  test "'update_guesses' updates correct single and first guess" do
     sender_id = "12345"
-    Redis.set(conn, sender_id, :chosen_word, "Bunda")
+
+    Redis.set(sender_id, :chosen_word, "Bunda")
 
     SyncGuesses.update_guesses("u", :correct_guesses, sender_id)
 
-    assert Redis.get_key_value(conn, sender_id, :correct_guesses) == "u"
+    assert Redis.get_key_value(sender_id, :correct_guesses) == "u"
   end
 
-  test "'update_guesses' updates more correct guesses", %{conn: conn} do
+  test "'update_guesses' updates more correct guesses" do
     sender_id = "123456"
-    Redis.set(conn, sender_id, :chosen_word, "Bunda")
-    Redis.set(conn, sender_id, :correct_guesses, "nd")
+    Redis.set(sender_id, :chosen_word, "Bunda")
+    Redis.set(sender_id, :correct_guesses, "nd")
 
     SyncGuesses.update_guesses("u", :correct_guesses, sender_id)
 
-    assert Redis.get_key_value(conn, sender_id, :correct_guesses) == "und"
+    assert Redis.get_key_value(sender_id, :correct_guesses) == "und"
   end
 
-  test "'update_guesses' updates single and incorrect first guess", %{conn: conn} do
+  test "'update_guesses' updates single and incorrect first guess" do
     sender_id = "1234567";
-    Redis.set(conn, sender_id, :chosen_word, "Bunda")
+    Redis.set(sender_id, :chosen_word, "Bunda")
 
     SyncGuesses.update_guesses("q", :incorrect_guesses, sender_id)
 
-    assert Redis.get_key_value(conn, sender_id, :incorrect_guesses) == "q"
+    assert Redis.get_key_value(sender_id, :incorrect_guesses) == "q"
   end
 
-  test "'update_guesses' updates more incorrect guesses", %{conn: conn} do
+  test "'update_guesses' updates more incorrect guesses" do
     sender_id = "12345678"
-    Redis.set(conn, sender_id, :chosen_word, "Bunda")
-    Redis.set(conn, sender_id, :incorrect_guesses, "ls")
+    Redis.set(sender_id, :chosen_word, "Bunda")
+    Redis.set(sender_id, :incorrect_guesses, "ls")
 
     SyncGuesses.update_guesses("w", :incorrect_guesses, sender_id)
 
-    assert Redis.get_key_value(conn, sender_id, :incorrect_guesses) == "wls"
+    assert Redis.get_key_value(sender_id, :incorrect_guesses) == "wls"
   end
 
-  test "'reset_all_guesses' reset all guesses", %{conn: conn} do
+  test "'reset_all_guesses' reset all guesses" do
     sender_id = "12345678"
-    Redis.set(conn, sender_id, :chosen_word, "Bunda")
-    Redis.set(conn, sender_id, :incorrect_guesses, "ls")
+    Redis.set(sender_id, :chosen_word, "Bunda")
+    Redis.set(sender_id, :incorrect_guesses, "ls")
 
     SyncGuesses.reset_all_guesses(sender_id)
 
-    assert Redis.get_key_value(conn, sender_id, :incorrect_guesses) == ""
-    assert Redis.get_key_value(conn, sender_id, :correct_guesses) == ""
+    assert Redis.get_key_value(sender_id, :incorrect_guesses) == ""
+    assert Redis.get_key_value(sender_id, :correct_guesses) == ""
   end
-
-  defp stub_random_word_response() do
-    %HTTPotion.Response{
-      body: "{\"id\":349663,\"word\":\"unstepped\"}",
-      headers: %HTTPotion.Headers{
-        hdrs: %{
-          "access-control-allow-headers" => "Origin, X-Atmosphere-tracking-id, X-Atmosphere-Framework, X-Cache-Date, Content-Type, X-Atmosphere-Transport, X-Remote, api_key, auth_token, *",
-          "access-control-allow-methods" => "POST, GET, OPTIONS, PUT, DELETE",
-          "access-control-allow-origin" => "*",
-          "access-control-request-headers" => "Origin, X-Atmosphere-tracking-id, X-Atmosphere-Framework, X-Cache-Date, Content-Type, X-Atmosphere-Transport,  X-Remote, api_key, *",
-          "connection" => "close",
-          "content-type" => "application/json; charset=utf-8",
-          "date" => "Wed, 03 Jan 2018 19:29:45 GMT",
-          "wordnik-api-version" => "4.12.20"
-        }
-      },
-     status_code: 200
-    }
-  end
-
-  defp stub_translation() do
-    %HTTPotion.Response{
-      body: "{\"code\":200,\"lang\":\"en-pt\",\"text\":[\"Mar Adriático\"]}",
-      headers: %HTTPotion.Headers{
-        hdrs: %{
-          "cache-control" => "no-store",
-          "connection" => "keep-alive", "content-length" => "53",
-          "content-type" => "application/json; charset=utf-8",
-          "date" => "Wed, 03 Jan 2018 19:40:48 GMT", "keep-alive" => "timeout=120",
-          "server" => "nginx/1.6.2", "x-content-type-options" => "nosniff"
-        }
-      },
-     status_code: 200
-    }
-  end
-
-  defp redis_host(), do: Application.get_env(:tbot, :redis_host)
 end

--- a/test/tbot_web/tbot_redis_test.exs
+++ b/test/tbot_web/tbot_redis_test.exs
@@ -1,54 +1,47 @@
-defmodule Tbot.RedisTest do
-  use TbotWeb.ConnCase
+# defmodule Tbot.RedisTest do
+#   use TbotWeb.ConnCase
 
-  alias Tbot.Redis, as: Redis
+#   alias Tbot.Redis, as: Redis
 
-  setup_all do
-    {:ok, conn} = Redix.start_link(redis_host())
-    Redix.command!(conn, ["FLUSHDB"])
-    Redix.stop(conn)
-    :ok
-  end
+#   setup_all do
+#     {:ok, conn} = Redix.start_link(redis_host())
+#     Redix.command!(conn, ["FLUSHDB"])
+#     Redix.stop(conn)
+#     :ok
+#   end
 
-  setup context do
-    if context[:no_setup] do
-      {:ok, %{}}
-    else
-      {:ok, conn} = Redix.start_link(redis_host())
-      {:ok, %{conn: conn}}
-    end
-  end
+#   setup context do
+#     if context[:no_setup] do
+#       {:ok, %{}}
+#     else
+#       {:ok, conn} = Redix.start_link(redis_host())
+#       {:ok, %{conn: conn}}
+#     end
+#   end
 
-  @tag :no_setup
-  test "'start_link' starts new link" do
-    conn = Redis.start_link
+#   test "'set' adds new key and value to hash", %{conn: c} do
+#     Redis.set(c, "12345", "prepara", "que agora")
+#     Redis.set(c, "12345", "é hora do show", "das poderosas")
 
-    assert is_pid(conn) == true
-  end
+#     assert Redix.command(c, ["HGETALL", "12345"]) ==
+#       {:ok, ["prepara", "que agora", "é hora do show", "das poderosas"]}
+#   end
 
-  test "'set' adds new key and value to hash", %{conn: c} do
-    Redis.set(c, "12345", "prepara", "que agora")
-    Redis.set(c, "12345", "é hora do show", "das poderosas")
+#   test "'get_members' returns all hash members", %{conn: c} do
+#     Redis.set(c, "12345", "prepara", "que agora")
+#     Redis.set(c, "12345", "é hora do show", "das poderosas")
+#     members = Redis.get_members(c, "12345")
 
-    assert Redix.command(c, ["HGETALL", "12345"]) ==
-      {:ok, ["prepara", "que agora", "é hora do show", "das poderosas"]}
-  end
+#     assert Redix.command(c, ["HGETALL", "12345"]) == {:ok, members}
+#   end
 
-  test "'get_members' returns all hash members", %{conn: c} do
-    Redis.set(c, "12345", "prepara", "que agora")
-    Redis.set(c, "12345", "é hora do show", "das poderosas")
-    members = Redis.get_members(c, "12345")
+#   test "'get_key_value' returns all hash's key value", %{conn: c} do
+#     Redis.set(c, "12345", "prepara", "que agora")
+#     Redis.set(c, "12345", "é hora do show", "das poderosas")
+#     value = Redis.get_key_value(c, "12345", "prepara")
 
-    assert Redix.command(c, ["HGETALL", "12345"]) == {:ok, members}
-  end
+#     assert Redix.command(c, ["HGET", "12345", "prepara"]) == {:ok, value}
+#   end
 
-  test "'get_key_value' returns all hash's key value", %{conn: c} do
-    Redis.set(c, "12345", "prepara", "que agora")
-    Redis.set(c, "12345", "é hora do show", "das poderosas")
-    value = Redis.get_key_value(c, "12345", "prepara")
-
-    assert Redix.command(c, ["HGET", "12345", "prepara"]) == {:ok, value}
-  end
-
-  defp redis_host(), do: Application.get_env(:tbot, :redis_host)
-end
+#   defp redis_host(), do: Application.get_env(:tbot, :redis_host)
+# end

--- a/test/tbot_web/tbot_redis_test.exs
+++ b/test/tbot_web/tbot_redis_test.exs
@@ -1,47 +1,34 @@
-# defmodule Tbot.RedisTest do
-#   use TbotWeb.ConnCase
+defmodule Tbot.RedisTest do
+  use TbotWeb.ConnCase
 
-#   alias Tbot.Redis, as: Redis
+  alias Tbot.Redis, as: Redis
 
-#   setup_all do
-#     {:ok, conn} = Redix.start_link(redis_host())
-#     Redix.command!(conn, ["FLUSHDB"])
-#     Redix.stop(conn)
-#     :ok
-#   end
+  setup do
+    Redis.command(["FLUSHDB"])
+    :ok
+  end
 
-#   setup context do
-#     if context[:no_setup] do
-#       {:ok, %{}}
-#     else
-#       {:ok, conn} = Redix.start_link(redis_host())
-#       {:ok, %{conn: conn}}
-#     end
-#   end
+  test "'set' adds new key and value to hash" do
+    Redis.set("12345", "prepara", "que agora")
+    Redis.set("12345", "é hora do show", "das poderosas")
 
-#   test "'set' adds new key and value to hash", %{conn: c} do
-#     Redis.set(c, "12345", "prepara", "que agora")
-#     Redis.set(c, "12345", "é hora do show", "das poderosas")
+    assert Redis.command(["HGETALL", "12345"]) ==
+      {:ok, ["prepara", "que agora", "é hora do show", "das poderosas"]}
+  end
 
-#     assert Redix.command(c, ["HGETALL", "12345"]) ==
-#       {:ok, ["prepara", "que agora", "é hora do show", "das poderosas"]}
-#   end
+  test "'get_members' returns all hash members" do
+    Redis.set("12345", "prepara", "que agora")
+    Redis.set("12345", "é hora do show", "das poderosas")
+    members = Redis.get_members("12345")
 
-#   test "'get_members' returns all hash members", %{conn: c} do
-#     Redis.set(c, "12345", "prepara", "que agora")
-#     Redis.set(c, "12345", "é hora do show", "das poderosas")
-#     members = Redis.get_members(c, "12345")
+    assert Redis.command(["HGETALL", "12345"]) == {:ok, members}
+  end
 
-#     assert Redix.command(c, ["HGETALL", "12345"]) == {:ok, members}
-#   end
+  test "'get_key_value' returns all hash's key value" do
+    Redis.set("12345", "prepara", "que agora")
+    Redis.set("12345", "é hora do show", "das poderosas")
+    value = Redis.get_key_value("12345", "prepara")
 
-#   test "'get_key_value' returns all hash's key value", %{conn: c} do
-#     Redis.set(c, "12345", "prepara", "que agora")
-#     Redis.set(c, "12345", "é hora do show", "das poderosas")
-#     value = Redis.get_key_value(c, "12345", "prepara")
-
-#     assert Redix.command(c, ["HGET", "12345", "prepara"]) == {:ok, value}
-#   end
-
-#   defp redis_host(), do: Application.get_env(:tbot, :redis_host)
-# end
+    assert Redis.command(["HGET", "12345", "prepara"]) == {:ok, value}
+  end
+end

--- a/test/tbot_web/tbot_sync_user_chosen_word_test.exs
+++ b/test/tbot_web/tbot_sync_user_chosen_word_test.exs
@@ -2,13 +2,12 @@ defmodule Tbot.SyncUserChosenWordTest do
   use TbotWeb.ConnCase
 
   alias Tbot.SyncUserChosenWord, as: SyncUserChosenWord
+  alias Tbot.Redis
 
   import Mock
 
-  setup_all do
-    {:ok, conn} = Redix.start_link(redis_host())
-    Redix.command!(conn, ["FLUSHDB"])
-    Redix.stop(conn)
+  setup do
+    Redis.command(["FLUSHDB"])
     :ok
   end
 
@@ -22,8 +21,7 @@ defmodule Tbot.SyncUserChosenWordTest do
 
       assert sync == {:ok, 1}
 
-      {:ok, conn} = Redix.start_link(redis_host())
-      assert Redix.command(conn, ["HGETALL", "12345"]) == {:ok, ["chosen_word", "Mar Adriático"]}
+      assert Redis.get_members("12345") == ["chosen_word", "Mar Adriático"]
     end
   end
 
@@ -61,6 +59,4 @@ defmodule Tbot.SyncUserChosenWordTest do
      status_code: 200
     }
   end
-
-  defp redis_host(), do: Application.get_env(:tbot, :redis_host)
 end


### PR DESCRIPTION
Hi,

Here we alter the manner to connect with Redis. For every incoming request, a new connection was being spawned, which led to the maximum number of clients being reached in production.

Now there is a Redis connection pool registered under a supervision tree. All instances of Redis can connect to Redis without the need to have the PID.