### PR TITLE
Parse redis_pool_size environment variable into a integer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,8 +13,18 @@ config :tbot, TbotWeb.Endpoint,
   pubsub: [name: Tbot.PubSub,
            adapter: Phoenix.PubSub.PG2]
 
+
+pool_size = fn () ->
+  env_pool_size = System.get_env("REDIS_POOL_SIZE")
+  pool_size = case env_pool_size do
+    nil -> 50
+    ""  -> 50
+    _ -> Integer.parse(env_pool_size)
+  end
+end
+
 config :tbot,
-  redis_pool_size: System.get_env("REDIS_POOL_SIZE") || 50
+  redis_pool_size: pool_size.()
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/lib/tbot/application.ex
+++ b/lib/tbot/application.ex
@@ -30,9 +30,10 @@ defmodule Tbot.Application do
   end
 
   defp redis_pool() do
-    pool_size = Application.get_env(:tbot, :redis_pool_size)
-    redix_workers = for i <- 0..(pool_size - 1) do
+    for i <- 0..(redis_pool_size() - 1) do
       worker(Redix, [[], [name: :"redix_#{i}"]], id: {Redix, i})
     end
   end
+
+  defp redis_pool_size(), do: Application.get_env(:tbot, :redis_pool_size)
 end

--- a/lib/tbot_web/hangman/tbot_hangman_sync_guesses.ex
+++ b/lib/tbot_web/hangman/tbot_hangman_sync_guesses.ex
@@ -6,7 +6,6 @@ defmodule Tbot.HangmanSyncGuesses do
   """
 
   alias Tbot.Redis
-  alias Tbot.HangmanWord, as: NewChosenWord
 
   def update_guesses(guess, guess_flag, sender_id) do
     existent_guesses = Redis.get_key_value(sender_id, guess_flag)

--- a/lib/tbot_web/tbot_redis.ex
+++ b/lib/tbot_web/tbot_redis.ex
@@ -23,5 +23,4 @@ defmodule Tbot.Redis do
   end
 
   defp redis_pool_size(), do: Application.get_env(:tbot, :redis_pool_size)
-  defp redis_host(), do: Application.get_env(:tbot, :redis_host)
 end


### PR DESCRIPTION
Hi,

I discovered that `System.get_env/1` returns only strings, which means that even if set to an integer, the variable will be a string. This lead to causes in production. Given that there is no `System.get_env/2` and `System.get_env/3` I had to add a `case` statement.